### PR TITLE
Bug discord image expiration for vision

### DIFF
--- a/tests/url-helpers.test.js
+++ b/tests/url-helpers.test.js
@@ -1,0 +1,41 @@
+const { isDiscordCDN, getQueryParamValue } = require('../util/url-helpers');
+
+describe('isDiscordCDN', () => {
+
+  test('Valid Discord CDN URL', () => {
+    const url = 'https://cdn.discordapp.com/attachments/1234567890/example.png';
+    expect(isDiscordCDN(url)).toBe(true);
+  });
+
+  test('Invalid CDN URL', () => {
+    const url = 'https://example.com/attachments/123/example.png';
+    expect(isDiscordCDN(url)).toBe(false);
+  });
+});
+
+describe('getQueryParamValue', () => {
+
+  test('Query parameter exists', () => {
+    const url = 'https://example.com/path?ex=1234&param=value';
+    const key = 'ex';
+    expect(getQueryParamValue(url, key)).toBe('1234');
+  });
+
+  test('Query parameter does not exist', () => {
+    const url = 'https://example.com/path?param=value';
+    const key = 'ex';
+    expect(getQueryParamValue(url, key)).toBe(null);
+  });
+
+  test('Empty string as URL', () => {
+    const url = '';
+    const key = 'ex';
+    expect(getQueryParamValue(url, key)).toBe(null);
+  });
+
+  test('Query parameter without value', () => {
+    const url = 'https://example.com/path?ex=&param=value';
+    const key = 'ex';
+    expect(getQueryParamValue(url, key)).toBe('');
+  });
+});

--- a/util/url-helpers.js
+++ b/util/url-helpers.js
@@ -1,0 +1,46 @@
+/**
+ * Checks if a given URL belongs to the domain `cdn.discordapp.com`.
+ * @param {string} url - The URL to be checked.
+ * @returns {boolean} - Returns true if the URL is from `cdn.discordapp.com`, false otherwise.
+ */
+function isDiscordCDN(url) {
+    try {
+        return new URL(url).hostname === 'cdn.discordapp.com';
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Extracts the value of a specific query parameter from a given URL.
+ * @param {string} url - The URL to be checked.
+ * @param {string} key - The query parameter key to retrieve.
+ * @returns {string|null} - Returns the value of the specified parameter if it exists, or null if it does not.
+ */
+function getQueryParamValue(url, key) {
+    try {
+        const params = new URL(url).searchParams;
+        return params.has(key) ? params.get(key) : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Converts a hexadecimal value to its decimal equivalent.
+ * @param {string} hexValue - The hexadecimal value to convert.
+ * @returns {number|null} - Returns the decimal equivalent, or null if the input is invalid.
+ */
+function hexToDecimal(hexValue) {
+    try {
+        return parseInt(hexValue, 16);
+    } catch {
+        return null;
+    }
+}
+
+module.exports = {
+    isDiscordCDN,
+    getQueryParamValue,
+    hexToDecimal,
+};


### PR DESCRIPTION
Fixes this really annoying bug where the image URLs in attached to the context window for use with the Vision api. Basically each time we fetch the context we check for expired images using the `ex` param on the image URL itself. Seems to work!